### PR TITLE
show Page title

### DIFF
--- a/docs/todo.org
+++ b/docs/todo.org
@@ -24,10 +24,10 @@
 **** [x] v0.0.3: AL: Move production code to server.py, test remaining
 **** [x] v0.0.3: AL: Remove deadcode and files (first-task)
 **** [x] v0.0.3: SR: Document start, update requirements & test once (first-task)
-**** [ ] v0.0.3: SR: Remove duplicate URLS (first-task)
-**** [ ] v0.0.3: SR: AtExit does not seem to work if you trap signals (first-task)
+**** [x] v0.0.3: SR: Remove duplicate URLS (first-task)
+**** [x] v0.0.3: SR: AtExit does not seem to work if you trap signals (first-task)
           https://stackoverflow.com/questions/40866576/run-atexit-when-python-process-is-killed)
-**** [ ] v0.0.3: SR: Store and send back page title (first-task)
+**** [x] v0.0.3: SR: Store and send back page title (first-task)
 ***** [ ] v0.0.3: BE: Capture page title & store in database, update API to return same
 ***** [ ] v0.0.3: UI: Show page title, truncate when too large and show ...
 **** [ ] v0.0.3: SR: Datetime handle (first-task)


### PR DESCRIPTION
Implement title extraction and integrate into backend

- Added functionality to extract titles from web pages and send them to the backend via the `/update` endpoint.
- Integrated title extraction into the similarity system, storing titles in metadata.
- Implemented fallback to display domain names when titles are unavailable.
- Updated frontend to display truncated titles and clean URLs using the `extractDomain` function.
- Refined search results to include titles, URLs, and context.
